### PR TITLE
build: use commonjs type since rollup is generating commonjs modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "stencileslint",
     "stencil eslint"
   ],
-  "type": "module",
   "main": "dist/index.js",
   "types": "dist/build/index.d.ts",
   "files": [


### PR DESCRIPTION
It looks like rollup outputs commonjs files:

https://github.com/jcfranco/stencil-eslint-core/blob/ce5c755cf66ffb02e9eae41ddd4b8569a1f6afad/rollup.config.js#L18-L21

The `type` was changed to "module" in `stencil-eslint-core@0.4.0`, which caused linting errors on the `rc` branch of the calcite monorepo:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/node_modules/stencil-eslint-core/dist/index.js from /home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/dist/index.js not supported.
/home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/node_modules/stencil-eslint-core/dist/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename /home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/node_modules/stencil-eslint-core/dist/index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/node_modules/stencil-eslint-core/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/home/ben/dev/work/calcite-design-system/rc/packages/eslint-plugin-calcite-components/dist/index.js:7:25)
    at ConfigArrayFactory._loadPlugin (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3423:42)
    at ConfigArrayFactory._loadExtendedPluginConfig (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3224:29)
    at ConfigArrayFactory._loadExtends (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3145:29)
    at ConfigArrayFactory._normalizeObjectConfigDataBody (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3086:25)
    at _normalizeObjectConfigDataBody.next (<anonymous>)
    at ConfigArrayFactory._normalizeObjectConfigData (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3031:20)
    at _normalizeObjectConfigData.next (<anonymous>)
    at ConfigArrayFactory.loadInDirectory (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2877:28)
    at CascadingConfigArrayFactory._loadConfigInAncestors (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3860:46)
    at CascadingConfigArrayFactory._loadConfigInAncestors (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3879:20)
    at CascadingConfigArrayFactory.getConfigArrayForFile (/home/ben/dev/work/calcite-design-system/rc/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:3781:18)
    at FileEnumerator._iterateFilesWithFile (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/cli-engine/file-enumerator.js:368:43)
    at FileEnumerator._iterateFiles (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/cli-engine/file-enumerator.js:349:25)
    at FileEnumerator.iterateFiles (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/cli-engine/file-enumerator.js:299:59)
    at iterateFiles.next (<anonymous>)
    at CLIEngine.executeOnFiles (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/cli-engine/cli-engine.js:797:48)
    at ESLint.lintFiles (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/eslint/eslint.js:551:23)
    at Object.execute (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/lib/cli.js:402:36)
    at async main (/home/ben/dev/work/calcite-design-system/rc/node_modules/eslint/bin/eslint.js:152:22)
```